### PR TITLE
Suggestion for argparse fixes

### DIFF
--- a/gwswlib/scripts.py
+++ b/gwswlib/scripts.py
@@ -94,7 +94,7 @@ def get_parser():
         default="postgres",
         metavar="USERNAME",
         dest="threedi_user",
-        help="username of your threedi database\n (default: 'postgres')",
+        help="username of your threedi database",
     )
     group_threedi.add_argument(
         "--threedi_password",

--- a/gwswlib/scripts.py
+++ b/gwswlib/scripts.py
@@ -5,7 +5,7 @@ A library for the GWSW-hydx exchange format
 Consists of a import and export functionality for currently hydx and threedi.
 Author: Arnold van 't Veld - Nelen & Schuurmans
 """
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import logging
 import sys
 
@@ -40,7 +40,9 @@ def run_import_export(
 
 def get_parser():
     """ Return argument parser. """
-    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser = ArgumentParser(
+        description=__doc__, formatter_class=ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
         "-v",
         "--verbose",
@@ -53,17 +55,15 @@ def get_parser():
         "--import",
         dest="import_type",
         default="hydx",
-        metavar="IMPORT_TYPE",
         choices=["hydx", "threedi"],
-        help="select your import operator:\n hydx (default) or threedi (not implemented)",
+        help="select your import operator",
     )
     parser.add_argument(
         "--export",
         dest="export_type",
         default="threedi",
-        metavar="EXPORT_TYPE",
         choices=["hydx", "threedi", "json"],
-        help="select your import operator:\n hydx (not implemented), threedi or json (not implemented)",
+        help="select your export operator",
     )
 
     group_import_hydx = parser.add_argument_group("Import or export a hydx")
@@ -72,8 +72,7 @@ def get_parser():
         default="gwswlib\\tests\\example_files_structures_hydx",
         metavar="HYDX_PATH",
         dest="hydx_path",
-        help='Folder with your hydx *.csv files\n\
-            (example: "gwswlib\\tests\\example_files_structures_hydx\\")',
+        help="Folder with your hydx *.csv files",
     )
     group_threedi = parser.add_argument_group("Import or export a 3di database")
     group_threedi.add_argument(
@@ -81,14 +80,14 @@ def get_parser():
         metavar="DBNAME",
         default="test_gwsw",
         dest="threedi_dbname",
-        help="name of your threedi database\n (example: 'test_gwsw')",
+        help="name of your threedi database",
     )
     group_threedi.add_argument(
         "--threedi_host",
         default="localhost",
         metavar="HOST",
         dest="threedi_host",
-        help="host of your threedi database\n (default: 'localhost')",
+        help="host of your threedi database",
     )
     group_threedi.add_argument(
         "--threedi_user",
@@ -102,7 +101,7 @@ def get_parser():
         default="postgres",
         metavar="PASSWORD",
         dest="threedi_password",
-        help="password of your threedi database\n (default: 'postgres')",
+        help="password of your threedi database",
     )
     group_threedi.add_argument(
         "--threedi_port",
@@ -110,7 +109,7 @@ def get_parser():
         type=int,
         metavar="PORT",
         dest="threedi_port",
-        help="port of your threedi database\n (default: '5432')",
+        help="port of your threedi database",
     )
     return parser
 


### PR DESCRIPTION
The `ArgumentDefaultsHelpFormatter` automatically shows the defaults. This
ensures two things:

- The db user/pass/etc defaults are shown (they were previously missing, which
  I needed for setting up travis :-) )

- The defaults always match exactly the actual defaults. There is no
  possibility for the documentation and the code to drift apart.

I had to remove `metavar` in some places, as that one gets used instead of
defaults if it is specified.

Note that the extra message about some options not being implemented isn't
shown anymore due to the formatting changes. If you want that back, I'd
suggest an addition to `ArgumentParser()`: `epilog="Note, x and y aren't
implemented yet"`